### PR TITLE
Specify box main thread stack sizes

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/meriac/mbed-os/#e64949e0172c2156160f6900c249dd96aa4e6065
+https://github.com/meriac/mbed-os/#2b3b1664308af86fbbf2103fcea4e2c6ed16ffcd

--- a/source/led1.cpp
+++ b/source/led1.cpp
@@ -18,7 +18,7 @@ static void led1_main(const void *);
 
 UVISOR_BOX_NAMESPACE(NULL);
 UVISOR_BOX_HEAPSIZE(8192);
-UVISOR_BOX_MAIN(led1_main, osPriorityNormal);
+UVISOR_BOX_MAIN(led1_main, osPriorityNormal, UVISOR_BOX_STACK_SIZE);
 UVISOR_BOX_CONFIG(box_led1, acl, UVISOR_BOX_STACK_SIZE, box_context);
 
 static void run_1(const void *)

--- a/source/led2.cpp
+++ b/source/led2.cpp
@@ -15,7 +15,7 @@ static void led2_main(const void *);
 
 UVISOR_BOX_NAMESPACE(NULL);
 UVISOR_BOX_HEAPSIZE(8192);
-UVISOR_BOX_MAIN(led2_main, osPriorityNormal);
+UVISOR_BOX_MAIN(led2_main, osPriorityNormal, UVISOR_BOX_STACK_SIZE);
 UVISOR_BOX_CONFIG(box_led2, acl, UVISOR_BOX_STACK_SIZE, box_context);
 
 static void led2_main(const void *)

--- a/source/led3.cpp
+++ b/source/led3.cpp
@@ -15,7 +15,7 @@ static void led3_main(const void *);
 
 UVISOR_BOX_NAMESPACE(NULL);
 UVISOR_BOX_HEAPSIZE(8192);
-UVISOR_BOX_MAIN(led3_main, osPriorityNormal);
+UVISOR_BOX_MAIN(led3_main, osPriorityNormal, UVISOR_BOX_STACK_SIZE);
 UVISOR_BOX_CONFIG(box_led3, acl, UVISOR_BOX_STACK_SIZE, box_context);
 
 static void led3_main(const void *)


### PR DESCRIPTION
This is ready for mergin'.

This commit updates mbed-os.lib at the same time to get the necessary changes from uVisor
for the UVISOR_BOX_MAIN macro.

@AlessandroA @niklas-arm @meriac
