### PR TITLE
Add secure allocator test code to boxes.

### DIFF
--- a/source/fun_bag.cpp
+++ b/source/fun_bag.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "fun_bag.h"
+#include "mbed.h"
+#include "rtos.h"
+#include <stdio.h>
+
+UVISOR_EXTERN void alloc_wait_free(size_t size, uint32_t wait_ms)
+{
+    void * memory;
+
+    /* Allocate a memory region. */
+    memory = malloc(size);
+    if (!memory) {
+        printf("malloc failed: %s:%u\n", __FILE__, __LINE__);
+        uvisor_error(USER_NOT_ALLOWED);
+    }
+
+    /* Optionally wait. */
+    if (wait_ms > 0) {
+        Thread::wait(wait_ms);
+    }
+
+    /* Free the memory region. */
+    free(memory);
+}

--- a/source/fun_bag.cpp
+++ b/source/fun_bag.cpp
@@ -19,7 +19,62 @@
 #include "rtos.h"
 #include <stdio.h>
 
-UVISOR_EXTERN void alloc_wait_free(size_t size, uint32_t wait_ms)
+/* Polynomial selected from Koopman's list of Maximal Length LFSR Feedback
+ * Terms <https://users.ece.cmu.edu/~koopman/lfsr/16.txt>. */
+static const uint16_t polynomial = 0x822B;
+
+/* Given the state of an LFSR (with the specific LFSR specified by the feedback
+ * polynomial), output the next state. */
+static uint16_t lfsr_next(uint16_t state, uint16_t poly)
+{
+    /* This code block is adapted from:
+     * https://en.wikipedia.org/wiki/Linear-feedback_shift_register#Galois_LFSRs
+     * https://en.wikipedia.org/wiki/Wikipedia:Text_of_Creative_Commons_Attribution-ShareAlike_3.0_Unported_License
+     */
+    uint16_t lsb = state & 1;
+    state >>= 1;
+    state ^= (-lsb) & poly;
+    return state;
+}
+
+/* Fill the memory region with a 16-bit pseudo-random number (PRN) sequence. */
+static void prn_fill(void * mem, uint16_t seed, size_t len)
+{
+    size_t i;
+    uint16_t state = seed;
+    uint8_t * m = (uint8_t *) mem;
+
+    for (i = 0; i < len; ++i) {
+        /* Just use the bottom byte. */
+        m[i] = state & 0xFF;
+        state = lfsr_next(state, polynomial);
+    }
+}
+
+/* Check that the memory region has the specified 16-bit PRN sequence. */
+/* Return non-zero if the region matches. Return zero if the region doesn't
+ * entirely match. */
+static int prn_verify(const void * mem, uint16_t seed, size_t len)
+{
+    size_t i;
+    uint16_t state = seed;
+    uint8_t * m = (uint8_t *) mem;
+    bool matches = true;
+
+    /* Check all of the bytes, even if we find a match sooner. This tests that
+     * we can read all of the memory (and that it hasn't been securely taken
+     * over by another box. */
+    for (i = 0; i < len; ++i) {
+        if (m[i] != (state & 0xFF)) {
+            matches = false;
+        }
+        state = lfsr_next(state, polynomial);
+    }
+
+    return matches;
+}
+
+UVISOR_EXTERN void alloc_fill_wait_verify_free(size_t size, uint16_t seed, uint32_t wait_ms)
 {
     void * memory;
 
@@ -30,9 +85,18 @@ UVISOR_EXTERN void alloc_wait_free(size_t size, uint32_t wait_ms)
         uvisor_error(USER_NOT_ALLOWED);
     }
 
+    /* Fill the entire memory region with a with PRN sequence. */
+    prn_fill(memory, seed, size);
+
     /* Optionally wait. */
     if (wait_ms > 0) {
         Thread::wait(wait_ms);
+    }
+
+    /* Verify the data we wrote is still there. */
+    if (!prn_verify(memory, seed, size)) {
+        printf("Verification failed: %s:%u\n", __FILE__, __LINE__);
+        uvisor_error(USER_NOT_ALLOWED);
     }
 
     /* Free the memory region. */

--- a/source/fun_bag.h
+++ b/source/fun_bag.h
@@ -24,9 +24,10 @@
 /* This file contains abstract functions for oft-repeated patterns in our
  * example. */
 
-/* Allocate a memory region of a given size, wait the specified length of time
- * (if non-zero), and then free the memory region. If any operations fail, call
- * uvisor_halt. */
-UVISOR_EXTERN void alloc_wait_free(size_t size, uint32_t wait_ms);
+/* Allocate a memory region of a given size, write to the entire buffer using a
+ * PRN sequence based on the given seed, wait the specified length of time (if
+ * non-zero), verify the data previously written to the buffer, and then free
+ * the memory region. If any operations fail, call uvisor_halt. */
+UVISOR_EXTERN void alloc_fill_wait_verify_free(size_t size, uint16_t seed, uint32_t wait_ms);
 
 #endif

--- a/source/fun_bag.h
+++ b/source/fun_bag.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FUN_BAG_H
+#define FUN_BAG_H
+
+#include "uvisor-lib/uvisor-lib.h"
+#include <stdint.h>
+
+/* This file contains abstract functions for oft-repeated patterns in our
+ * example. */
+
+/* Allocate a memory region of a given size, wait the specified length of time
+ * (if non-zero), and then free the memory region. If any operations fail, call
+ * uvisor_halt. */
+UVISOR_EXTERN void alloc_wait_free(size_t size, uint32_t wait_ms);
+
+#endif

--- a/source/fun_bag.h
+++ b/source/fun_bag.h
@@ -30,4 +30,12 @@
  * the memory region. If any operations fail, call uvisor_halt. */
 UVISOR_EXTERN void alloc_fill_wait_verify_free(size_t size, uint16_t seed, uint32_t wait_ms);
 
+/* Using a specific allocator, allocate a memory region of a given size, write
+ * to the entire buffer using a PRN sequence based on the given seed, wait the
+ * specified length of time (if non-zero), verify the data previously written
+ * to the buffer, and then free the memory region. If any operations fail, call
+ * uvisor_halt. */
+UVISOR_EXTERN void specific_alloc_fill_wait_verify_free(SecureAllocator allocator,
+                                                        size_t size, uint16_t seed, uint32_t wait_ms);
+
 #endif

--- a/source/led1.cpp
+++ b/source/led1.cpp
@@ -61,6 +61,6 @@ static void led1_main(const void *)
 
         led1 = !led1;
         ++uvisor_ctx->heartbeat;
-        alloc_fill_wait_verify_free(size, seed, 200);
+        alloc_fill_wait_verify_free(size, seed, 211);
     }
 }

--- a/source/led1.cpp
+++ b/source/led1.cpp
@@ -1,3 +1,4 @@
+#include "fun_bag.h"
 #include "uvisor-lib/uvisor-lib.h"
 #include "mbed.h"
 #include "rtos.h"
@@ -24,11 +25,11 @@ UVISOR_BOX_CONFIG(box_led1, acl, UVISOR_BOX_STACK_SIZE, box_context);
 static void run_1(const void *)
 {
     while (1) {
-        void * memory;
+        const int toggle = uvisor_ctx->toggle;
+        uint16_t size = toggle ? 150 : 99;
 
-        memory = malloc(uvisor_ctx->toggle ? 150 : 99);
         uvisor_ctx->toggle = !uvisor_ctx->toggle;
-        free(memory);
+        alloc_wait_free(size, 0);
     }
 }
 
@@ -40,12 +41,10 @@ static void led1_main(const void *)
     uvisor_ctx->thread3 = new Thread(run_1);
 
     while (1) {
-        void * memory;
+        static const size_t size = 20;
 
         led1 = !led1;
         ++uvisor_ctx->heartbeat;
-        memory = malloc(20);
-        Thread::wait(200);
-        free(memory);
+        alloc_wait_free(size, 200);
     }
 }

--- a/source/led1.cpp
+++ b/source/led1.cpp
@@ -40,6 +40,9 @@ static void led1_main(const void *)
     led1 = LED_OFF;
     uvisor_ctx->thread2 = new Thread(run_1);
     uvisor_ctx->thread3 = new Thread(run_1);
+    const uint32_t kB = 1024;
+
+    SecureAllocator alloc = secure_allocator_create_with_pages(4*kB, 1*kB);
 
     while (1) {
         static const size_t size = 20;
@@ -48,5 +51,6 @@ static void led1_main(const void *)
         led1 = !led1;
         ++uvisor_ctx->heartbeat;
         alloc_fill_wait_verify_free(size, seed, 200);
+        specific_alloc_fill_wait_verify_free(alloc, 5*kB, seed, 100);
     }
 }

--- a/source/led1.cpp
+++ b/source/led1.cpp
@@ -6,10 +6,7 @@
 
 struct box_context {
     Thread * thread;
-    Thread * thread2;
-    Thread * thread3;
     uint32_t heartbeat;
-    int toggle;
 };
 
 static const UvisorBoxAclItem acl[] = {
@@ -22,45 +19,21 @@ UVISOR_BOX_HEAPSIZE(8192);
 UVISOR_BOX_MAIN(led1_main, osPriorityNormal, UVISOR_BOX_STACK_SIZE);
 UVISOR_BOX_CONFIG(box_led1, acl, UVISOR_BOX_STACK_SIZE, box_context);
 
-static void run_1(const void *)
-{
-    while (1) {
-        const int toggle = uvisor_ctx->toggle;
-        uint16_t size = toggle ? 150 : 99;
-        uint16_t seed = (size << 8) | (uvisor_ctx->heartbeat & 0xFF);
-
-        uvisor_ctx->toggle = !uvisor_ctx->toggle;
-        alloc_fill_wait_verify_free(size, seed, 0);
-    }
-}
-
 static void led1_main(const void *)
 {
     DigitalOut led1(LED1);
     led1 = LED_OFF;
-    uvisor_ctx->thread2 = new Thread(run_1);
-    uvisor_ctx->thread3 = new Thread(run_1);
-
-    /* Create page-backed allocator. */
     const uint32_t kB = 1024;
-    SecureAllocator alloc = secure_allocator_create_with_pages(4*kB, 1*kB);
-    /* Prepare the thread definition structure. */
-    osThreadDef_t thread_def;
-    thread_def.stacksize = DEFAULT_STACK_SIZE;
-    /* Allocate the stack inside the page allocator! */
-    thread_def.stack_pointer = (uint32_t *) secure_malloc(alloc, DEFAULT_STACK_SIZE);
-    thread_def.tpriority = osPriorityNormal;
-    thread_def.pthread = &run_1;
-    /* Create a thread with the page allocator as heap. */
-    osThreadContextCreate(&thread_def, NULL, alloc);
 
+    SecureAllocator alloc = secure_allocator_create_with_pages(4*kB, 1*kB);
 
     while (1) {
-        static const size_t size = 20;
+        static const size_t size = 500;
         uint16_t seed = (size << 8) | (uvisor_ctx->heartbeat & 0xFF);
 
         led1 = !led1;
         ++uvisor_ctx->heartbeat;
         alloc_fill_wait_verify_free(size, seed, 211);
+        specific_alloc_fill_wait_verify_free(alloc, 5*kB, seed, 107);
     }
 }

--- a/source/led1.cpp
+++ b/source/led1.cpp
@@ -27,9 +27,10 @@ static void run_1(const void *)
     while (1) {
         const int toggle = uvisor_ctx->toggle;
         uint16_t size = toggle ? 150 : 99;
+        uint16_t seed = (size << 8) | (uvisor_ctx->heartbeat & 0xFF);
 
         uvisor_ctx->toggle = !uvisor_ctx->toggle;
-        alloc_wait_free(size, 0);
+        alloc_fill_wait_verify_free(size, seed, 0);
     }
 }
 
@@ -42,9 +43,10 @@ static void led1_main(const void *)
 
     while (1) {
         static const size_t size = 20;
+        uint16_t seed = (size << 8) | (uvisor_ctx->heartbeat & 0xFF);
 
         led1 = !led1;
         ++uvisor_ctx->heartbeat;
-        alloc_wait_free(size, 200);
+        alloc_fill_wait_verify_free(size, seed, 200);
     }
 }

--- a/source/led2.cpp
+++ b/source/led2.cpp
@@ -45,12 +45,12 @@ static void led2_main(const void *)
 
         led2 = !led2;
         ++uvisor_ctx->heartbeat;
-        alloc_fill_wait_verify_free(size, seed, 300);
+        alloc_fill_wait_verify_free(size, seed, 311);
 
         /* Allocate in first page */
         specific_alloc_fill_wait_verify_free(alloc, 14*kB, seed, 0);
 
         /* Allocate in second page */
-        specific_alloc_fill_wait_verify_free(alloc, 14*kB, seed, 100);
+        specific_alloc_fill_wait_verify_free(alloc, 14*kB, seed, 101);
     }
 }

--- a/source/led2.cpp
+++ b/source/led2.cpp
@@ -26,9 +26,10 @@ static void led2_main(const void *)
 
     while (1) {
         static const size_t size = 300;
+        uint16_t seed = (size << 8) | (uvisor_ctx->heartbeat & 0xFF);
 
         led2 = !led2;
         ++uvisor_ctx->heartbeat;
-        alloc_wait_free(size, 300);
+        alloc_fill_wait_verify_free(size, seed, 300);
     }
 }

--- a/source/led2.cpp
+++ b/source/led2.cpp
@@ -26,18 +26,22 @@ static void led2_main(const void *)
     const uint32_t kB = 1024;
     SecureAllocator alloc;
 
-    {
-        /* Allocate one page. */
-        alloc = secure_allocator_create_with_pages(4*kB, 1*kB);
-        /* Allocate another page. */
-        SecureAllocator alloc2 = secure_allocator_create_with_pages(4*kB, 1*kB);
-        /* Deallocate alloc1 page, creating a hole. */
-        secure_allocator_destroy(alloc);
-        /* Allocate two pages. */
-        alloc = secure_allocator_create_with_pages(UVISOR_PAGE_SIZE + 12*kB, 6*kB);
-        /* Deallocate alloc2 page, creating another hole. */
-        secure_allocator_destroy(alloc2);
-    }
+    /* Create one allocator with two non-consecutive pages,
+     * by attempting to create a hole in the page allocator.
+     * This simulates a fragmented page heap, but note, that
+     * this method is not guaranteed to create a fragemented
+     * page heap!
+     */
+    /* Allocate one page. */
+    alloc = secure_allocator_create_with_pages(4*kB, 1*kB);
+    /* Allocate another page. */
+    SecureAllocator alloc2 = secure_allocator_create_with_pages(4*kB, 1*kB);
+    /* Deallocate alloc1 page, creating a hole. */
+    secure_allocator_destroy(alloc);
+    /* Allocate two pages. */
+    alloc = secure_allocator_create_with_pages(UVISOR_PAGE_SIZE + 12*kB, 6*kB);
+    /* Deallocate alloc2 page, creating another hole. */
+    secure_allocator_destroy(alloc2);
 
     while (1) {
         static const size_t size = 300;

--- a/source/led2.cpp
+++ b/source/led2.cpp
@@ -1,3 +1,4 @@
+#include "fun_bag.h"
 #include "uvisor-lib/uvisor-lib.h"
 #include "mbed.h"
 #include "rtos.h"
@@ -24,12 +25,10 @@ static void led2_main(const void *)
     led2 = LED_OFF;
 
     while (1) {
-        void * memory;
+        static const size_t size = 300;
 
         led2 = !led2;
         ++uvisor_ctx->heartbeat;
-        memory = malloc(300);
-        Thread::wait(300);
-        free(memory);
+        alloc_wait_free(size, 300);
     }
 }

--- a/source/led3.cpp
+++ b/source/led3.cpp
@@ -6,7 +6,10 @@
 
 struct box_context {
     Thread * thread;
+    Thread * thread2;
+    Thread * thread3;
     uint32_t heartbeat;
+    int toggle;
 };
 
 static const UvisorBoxAclItem acl[] = {
@@ -19,21 +22,45 @@ UVISOR_BOX_HEAPSIZE(8192);
 UVISOR_BOX_MAIN(led3_main, osPriorityNormal, UVISOR_BOX_STACK_SIZE);
 UVISOR_BOX_CONFIG(box_led3, acl, UVISOR_BOX_STACK_SIZE, box_context);
 
+static void run_3(const void *)
+{
+    while (1) {
+        const int toggle = uvisor_ctx->toggle;
+        uint16_t size = toggle ? 150 : 99;
+        uint16_t seed = (size << 8) | (uvisor_ctx->heartbeat & 0xFF);
+
+        uvisor_ctx->toggle = !uvisor_ctx->toggle;
+        alloc_fill_wait_verify_free(size, seed, 0);
+    }
+}
+
 static void led3_main(const void *)
 {
     DigitalOut led3(LED3);
     led3 = LED_OFF;
-    const uint32_t kB = 1024;
+    uvisor_ctx->thread2 = new Thread(run_3);
+    uvisor_ctx->thread3 = new Thread(run_3);
 
+    /* Create page-backed allocator. */
+    const uint32_t kB = 1024;
     SecureAllocator alloc = secure_allocator_create_with_pages(4*kB, 1*kB);
+    /* Prepare the thread definition structure. */
+    osThreadDef_t thread_def;
+    thread_def.stacksize = DEFAULT_STACK_SIZE;
+    /* Allocate the stack inside the page allocator! */
+    thread_def.stack_pointer = (uint32_t *) secure_malloc(alloc, DEFAULT_STACK_SIZE);
+    thread_def.tpriority = osPriorityNormal;
+    thread_def.pthread = &run_3;
+    /* Create a thread with the page allocator as heap. */
+    osThreadContextCreate(&thread_def, NULL, alloc);
+
 
     while (1) {
-        static const size_t size = 500;
+        static const size_t size = 20;
         uint16_t seed = (size << 8) | (uvisor_ctx->heartbeat & 0xFF);
 
         led3 = !led3;
         ++uvisor_ctx->heartbeat;
-        alloc_fill_wait_verify_free(size, seed, 503);
-        specific_alloc_fill_wait_verify_free(alloc, 5*kB, seed, 100);
+        alloc_fill_wait_verify_free(size, seed, 211);
     }
 }

--- a/source/led3.cpp
+++ b/source/led3.cpp
@@ -1,3 +1,4 @@
+#include "fun_bag.h"
 #include "uvisor-lib/uvisor-lib.h"
 #include "mbed.h"
 #include "rtos.h"
@@ -24,12 +25,10 @@ static void led3_main(const void *)
     led3 = LED_OFF;
 
     while (1) {
-        void * memory;
+        static const size_t size = 500;
 
         led3 = !led3;
-        memory = malloc(500);
         ++uvisor_ctx->heartbeat;
-        Thread::wait(500);
-        free(memory);
+        alloc_wait_free(size, 500);
     }
 }

--- a/source/led3.cpp
+++ b/source/led3.cpp
@@ -26,9 +26,10 @@ static void led3_main(const void *)
 
     while (1) {
         static const size_t size = 500;
+        uint16_t seed = (size << 8) | (uvisor_ctx->heartbeat & 0xFF);
 
         led3 = !led3;
         ++uvisor_ctx->heartbeat;
-        alloc_wait_free(size, 500);
+        alloc_fill_wait_verify_free(size, seed, 500);
     }
 }

--- a/source/led3.cpp
+++ b/source/led3.cpp
@@ -33,7 +33,7 @@ static void led3_main(const void *)
 
         led3 = !led3;
         ++uvisor_ctx->heartbeat;
-        alloc_fill_wait_verify_free(size, seed, 500);
+        alloc_fill_wait_verify_free(size, seed, 503);
         specific_alloc_fill_wait_verify_free(alloc, 5*kB, seed, 100);
     }
 }

--- a/source/led3.cpp
+++ b/source/led3.cpp
@@ -23,6 +23,9 @@ static void led3_main(const void *)
 {
     DigitalOut led3(LED3);
     led3 = LED_OFF;
+    const uint32_t kB = 1024;
+
+    SecureAllocator alloc = secure_allocator_create_with_pages(4*kB, 1*kB);
 
     while (1) {
         static const size_t size = 500;
@@ -31,5 +34,6 @@ static void led3_main(const void *)
         led3 = !led3;
         ++uvisor_ctx->heartbeat;
         alloc_fill_wait_verify_free(size, seed, 500);
+        specific_alloc_fill_wait_verify_free(alloc, 5*kB, seed, 100);
     }
 }

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -41,8 +41,8 @@ static void main_alloc(const void *)
     SecureAllocator alloc = secure_allocator_create_with_pages(4*kB, 1*kB);
 
     while (1) {
-        alloc_fill_wait_verify_free(500, seed, 500);
-        specific_alloc_fill_wait_verify_free(alloc, 5*kB, seed, 100);
+        alloc_fill_wait_verify_free(500, seed, 577);
+        specific_alloc_fill_wait_verify_free(alloc, 5*kB, seed, 97);
         seed++;
     }
 }

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "fun_bag.h"
 #include "uvisor-lib/uvisor-lib.h"
 #include "mbed.h"
 #include "rtos.h"
@@ -33,8 +34,23 @@ UVISOR_SET_PRIV_SYS_IRQ_HOOKS(SVC_Handler, PendSV_Handler, SysTick_Handler);
 /* Enable uVisor. */
 UVISOR_SET_MODE_ACL(UVISOR_ENABLED, g_main_acl);
 
+static void main_alloc(const void *)
+{
+    const uint32_t kB = 1024;
+    uint16_t seed = 0x10;
+    SecureAllocator alloc = secure_allocator_create_with_pages(4*kB, 1*kB);
+
+    while (1) {
+        alloc_fill_wait_verify_free(500, seed, 500);
+        specific_alloc_fill_wait_verify_free(alloc, 5*kB, seed, 100);
+        seed++;
+    }
+}
+
 int main(void)
 {
+    Thread * thread = new Thread(main_alloc);
+
     printf("\r\n***** threaded blinky uvisor-rtos example *****\r\n");
 
     size_t count = 0;


### PR DESCRIPTION
This adds page heap usage to the example to test the secured page heap features added in https://github.com/ARMmbed/uvisor/pull/267.

cc @meriac @AlessandroA @Patater 
