### PR TITLE
Use non-deprecated thread constructor and start

### DIFF
--- a/source/led3.cpp
+++ b/source/led3.cpp
@@ -5,9 +5,6 @@
 #include "main-hw.h"
 
 struct box_context {
-    Thread * thread;
-    Thread * thread2;
-    Thread * thread3;
     uint32_t heartbeat;
     int toggle;
 };
@@ -38,8 +35,8 @@ static void led3_main(const void *)
 {
     DigitalOut led3(LED3);
     led3 = LED_OFF;
-    uvisor_ctx->thread2 = new Thread(run_3);
-    uvisor_ctx->thread3 = new Thread(run_3);
+    Thread * thread1 = new Thread(run_3);
+    Thread * thread2 = new Thread(run_3);
 
     /* Create page-backed allocator. */
     const uint32_t kB = 1024;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -34,7 +34,7 @@ UVISOR_SET_PRIV_SYS_IRQ_HOOKS(SVC_Handler, PendSV_Handler, SysTick_Handler);
 /* Enable uVisor. */
 UVISOR_SET_MODE_ACL(UVISOR_ENABLED, g_main_acl);
 
-static void main_alloc(const void *)
+static void main_alloc(void)
 {
     const uint32_t kB = 1024;
     uint16_t seed = 0x10;
@@ -49,7 +49,13 @@ static void main_alloc(const void *)
 
 int main(void)
 {
-    Thread * thread = new Thread(main_alloc);
+    osStatus status;
+    Thread * thread = new Thread();
+    status = thread->start(main_alloc);
+    if (status != osOK) {
+        printf("Could not start main thread.\r\n");
+        uvisor_error(USER_NOT_ALLOWED);
+    }
 
     printf("\r\n***** threaded blinky uvisor-rtos example *****\r\n");
 


### PR DESCRIPTION
This should go in only after the mbed-os repo pointer has been updated.

mbed-os recently introduced a new thread constructor and deprecated the old thread constructor. This PR updates our example to avoid deprecation warnings.

@niklas-arm @AlessandroA @meriac
