### PR TITLE
Use targets override instead of custom targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,23 @@ process also updates some memory private to that process. The memory allocator
 is also used in this example.
 
 ## Building
-The example currently only works on K64F with the GCC_ARM tool chain.
+
+The example currently only works on K64F with the GCC_ARM toolchain.
+
 ### Release
-For normal compilation, please enter:
+
+For a release build, please enter:
+
 ```bash
-mbed compile -m K64F_SECURE -t GCC_ARM -c
+$ mbed compile -m K64F -t GCC_ARM
 ```
+
+You will find the resulting binary in `.build/K64F/GCC_ARM/mbed-os-example-uvisor.bin`. You can drag and drop it onto your board USB drive.
+
 ### Debug
-When connecting a debugger, output can be seen on the debug console:
+
+When a debugger is connected, you can observe debug output from uVisor. Please note that these messages are sent through semihosting, which halts the program execution if a debugger is not connected. For more information please read the [Debugging uVisor on mbed OS](https://github.com/ARMmbed/uvisor/blob/master/docs/api/DEBUGGING.md) guide. To build a debug version of the program:
+
 ```bash
-mbed compile -m K64F_SECURE -t GCC_ARM -c -o debug-info
+$ mbed compile -m K64F -t GCC_ARM -o "debug-info"
 ```

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b7b6dd2c8769251c66d68911f116ec899c7054f7
+https://github.com/mbedmicro/mbed#a4fb649789380fef02ccf535879d5e263de83c50

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,9 +1,8 @@
 {
-    "custom_targets": {
-        "K64F_SECURE": {
-            "inherits": ["K64F"],
-            "extra_labels_add":["K64F", "UVISOR_SUPPORTED"],
-            "features_add": ["UVISOR"]
+    "target_overrides": {
+        "K64F": {
+            "target.features_add": ["UVISOR"],
+            "target.extra_labels_add": ["UVISOR_SUPPORTED"]
         }
     }
 }


### PR DESCRIPTION
- `target_overrides` are used in place of custom targets to specify the uVisor macros.
- `mbed-os.lib` now points to mbedmicro/mbed, not ARMmbed/mbed-os.
- `README.md` updated accordingly.
