### PR TITLE
Add FEATURE_ and TARGET_ macros to the config file

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -4,5 +4,9 @@
             "target.features_add": ["UVISOR"],
             "target.extra_labels_add": ["UVISOR_SUPPORTED"]
         }
-    }
+    },
+    "macros": [
+        "FEATURE_UVISOR=1",
+        "TARGET_UVISOR_SUPPORTED=1"
+    ]
 }


### PR DESCRIPTION
Since mbed OS 5.1, ASM files do not define FEATURE_ and TARGET_ macros
any more.

Since the ASM startup file in uVisor-supported targets relies on such
symbols, we need to define them separately in the config file.

For C/C++ files, the old behavior still applies. A feature or target
overrides specified in the config file automatically triggers the
definition of those symbols.

@Patater 
