### PR TITLE
XXX WIP Replace UVISOR_PAGE_SIZE with uvisor_page_size()

### DIFF
--- a/source/led2.cpp
+++ b/source/led2.cpp
@@ -39,7 +39,7 @@ static void led2_main(const void *)
     /* Deallocate alloc1 page, creating a hole. */
     secure_allocator_destroy(alloc);
     /* Allocate two pages. */
-    alloc = secure_allocator_create_with_pages(UVISOR_PAGE_SIZE + 12*kB, 6*kB);
+    alloc = secure_allocator_create_with_pages(uvisor_get_page_size() + 12*kB, 6*kB);
     /* Deallocate alloc2 page, creating another hole. */
     secure_allocator_destroy(alloc2);
 


### PR DESCRIPTION
XXX Don't merge yet.

This isn't only XXX WIP because we haven't imported uVisor yet. After we import uVisor, this is ready to go.

This is needed after we re-run the uVisor importer script and update to the latest uVisor. The UVISOR_PAGE_SIZE macro has been removed in latest uVisor.

@AlessandroA @meriac
