### PR TITLE
Update for feature_cmsis5

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Supported devices:
 |--------|-----------|-----------|
 | `K64F` | `GCC_ARM` | 9600      |
 
-Latest release: [mbed-os-5.3.x](https://github.com/ARMmbed/mbed-os-example-uvisor/releases/latest). Tested with [mbed-cli v1.0.0](https://github.com/ARMmbed/mbed-cli/releases/tag/1.0.0).
+Latest release: [mbed-os-5.4.x](https://github.com/ARMmbed/mbed-os-example-uvisor/releases/latest). Tested with [mbed-cli v1.0.0](https://github.com/ARMmbed/mbed-cli/releases/tag/1.0.0).
 
 ## Quickstart
 

--- a/source/fun_bag.cpp
+++ b/source/fun_bag.cpp
@@ -58,7 +58,7 @@ static int prn_verify(const void * mem, uint16_t seed, size_t len)
 {
     size_t i;
     uint16_t state = seed;
-    uint8_t * m = (uint8_t *) mem;
+    const uint8_t * m = (const uint8_t *) mem;
     bool matches = true;
 
     /* Check all of the bytes, even if we find a match sooner. This tests that

--- a/source/fun_bag.cpp
+++ b/source/fun_bag.cpp
@@ -63,7 +63,7 @@ static int prn_verify(const void * mem, uint16_t seed, size_t len)
 
     /* Check all of the bytes, even if we find a match sooner. This tests that
      * we can read all of the memory (and that it hasn't been securely taken
-     * over by another box. */
+     * over by another box). */
     for (i = 0; i < len; ++i) {
         if (m[i] != (state & 0xFF)) {
             matches = false;

--- a/source/led1.cpp
+++ b/source/led1.cpp
@@ -22,11 +22,7 @@ UVISOR_BOX_HEAPSIZE(3 * 1024);
 UVISOR_BOX_MAIN(led1_main, osPriorityNormal, 512);
 UVISOR_BOX_CONFIG(box_led1, acl, 512, box_context);
 
-/* FIXME: The guard is needed for backwards-compatibility reasons. Remove it
- *        when mbed OS is updated. */
-#ifdef __uvisor_ctx
 #define uvisor_ctx ((box_context *) __uvisor_ctx)
-#endif
 
 static void led1_main(const void *)
 {

--- a/source/led2.cpp
+++ b/source/led2.cpp
@@ -22,11 +22,7 @@ UVISOR_BOX_HEAPSIZE(3 * 1024);
 UVISOR_BOX_MAIN(led2_main, osPriorityNormal, 512);
 UVISOR_BOX_CONFIG(box_led2, acl, 512, box_context);
 
-/* FIXME: The guard is needed for backwards-compatibility reasons. Remove it
- *        when mbed OS is updated. */
-#ifdef __uvisor_ctx
 #define uvisor_ctx ((box_context *) __uvisor_ctx)
-#endif
 
 static void led2_main(const void *)
 {

--- a/source/led3.cpp
+++ b/source/led3.cpp
@@ -22,11 +22,7 @@ UVISOR_BOX_HEAPSIZE(3 * 1024);
 UVISOR_BOX_MAIN(led3_main, osPriorityNormal, 1024);
 UVISOR_BOX_CONFIG(box_led3, acl, 512, box_context);
 
-/* FIXME: The guard is needed for backwards-compatibility reasons. Remove it
- *        when mbed OS is updated. */
-#ifdef __uvisor_ctx
 #define uvisor_ctx ((box_context *) __uvisor_ctx)
-#endif
 
 static void run_3(void)
 {

--- a/source/main-hw.h
+++ b/source/main-hw.h
@@ -45,6 +45,26 @@
         {SPI0,   sizeof(*SPI0),   UVISOR_TACLDEF_PERIPH}, \
     }
 
+#elif defined (TARGET_EFM32GG_STK3700)
+
+#define MAIN_LED           LED1
+#define SECURE_LED         LED2
+#define LED_ON             true
+#define LED_OFF            false
+#define SECURE_SWITCH      SW2
+#define SECURE_SWITCH_PULL PullUp
+
+#define MAIN_ACL(acl_list_name) \
+    static const UvisorBoxAclItem acl_list_name[] = {     \
+        {CMU,                 sizeof(*CMU),    UVISOR_TACLDEF_PERIPH}, \
+        {MSC,                 sizeof(*MSC),    UVISOR_TACLDEF_PERIPH}, \
+        {GPIO,                sizeof(*GPIO),   UVISOR_TACLDEF_PERIPH}, \
+        {TIMER0,              sizeof(*TIMER0), UVISOR_TACLDEF_PERIPH}, \
+        {UART0,               sizeof(*UART0),  UVISOR_TACLDEF_PERIPH}, \
+        {(void *) 0x0FE08000, 0x1000,          UVISOR_TACLDEF_PERIPH}, \
+        {(void *) 0x42000000, 0x2000000,       UVISOR_TACLDEF_PERIPH}, \
+    }
+
 #else /* Target-specific settings */
 
 #error "Unsupported target. Checkout the README.md file for the list of supported targets for this app."

--- a/test/filters.json
+++ b/test/filters.json
@@ -1,6 +1,6 @@
 {
     "blacklist" : [ {
-        "platforms" : ["EFM32GG_STK3700", "DISCO_F429ZI"]
+        "platforms" : ["DISCO_F429ZI"]
         }
     ]
 }


### PR DESCRIPTION
- Switch from RTX to RTX2, without breaking backwards compatibility
- Add EFM32GG support
- Clean up a bit

Verified example builds and runs successfully with both the latest mbed OS master branch and the latest mbed OS feature_cmsis5 branch.

(DejaVu? Note that the changes here are very similar to https://github.com/ARMmbed/mbed-os-example-uvisor-thread/pull/47)

@AlessandroA @niklas-arm 