### PR TITLE
Add PSA manifest files for partition description.

### DIFF
--- a/argparse_action_helper.py
+++ b/argparse_action_helper.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python
+# *************************************************
+# Copyright (c) 2016  ARM Ltd (or its subsidiaries)
+# *************************************************
+
+import argparse
+import os
+
+
+class StoreInputDir(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        prospective_dir = values
+        if not os.path.isdir(prospective_dir):
+            raise argparse.ArgumentTypeError('dir: "{0}" is not a valid path'.format(prospective_dir))
+        elif not os.access(prospective_dir, os.R_OK):
+            raise argparse.ArgumentTypeError('dir: "{0}" is not a readable dir'.format(prospective_dir))
+        setattr(namespace, self.dest, os.path.abspath(prospective_dir))
+
+
+class StoreOutputDir(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        prospective_dir = values
+        if not os.path.isdir(prospective_dir):
+            try:
+                os.makedirs(prospective_dir)
+            except os.error as e:
+                raise argparse.ArgumentTypeError('dir: {0} cannot be created: {1}'.format(prospective_dir, str(e)))
+        setattr(namespace, self.dest, os.path.abspath(prospective_dir))
+
+
+class StoreValidFile(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        prospective_file = values
+        if not os.path.isfile(prospective_file):
+            raise argparse.ArgumentTypeError('file: "{0}" not found'.format(prospective_file))
+        if not os.access(prospective_file, os.R_OK):
+            raise argparse.ArgumentTypeError('file: "{0}" is not a readable file'.format(prospective_file))
+        setattr(namespace, self.dest, os.path.abspath(prospective_file))
+
+
+class AppendValidFile(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        prospective_file = values
+        if not os.path.isfile(prospective_file):
+            raise argparse.ArgumentTypeError('file: "{0}" not found'.format(prospective_file))
+        if not os.access(prospective_file, os.R_OK):
+            raise argparse.ArgumentTypeError('file: "{0}" is not a readable file'.format(prospective_file))
+        if not getattr(namespace, self.dest):
+            setattr(namespace, self.dest, [])
+        getattr(namespace, self.dest).append(os.path.abspath(prospective_file))

--- a/generate_partition_code.py
+++ b/generate_partition_code.py
@@ -1,0 +1,320 @@
+#!/usr/bin/python
+import argparse
+import sys
+import os
+import re
+import fnmatch
+import logging
+from lxml import etree
+from jinja2 import Environment, FileSystemLoader
+from argparse_action_helper import StoreInputDir
+from argparse_action_helper import StoreOutputDir
+
+script_dir = os.path.dirname(os.path.abspath(__file__))
+logger = logging.getLogger('uVisor')
+
+def to_number(num_str, error_message):
+    """
+    Convert a given string to an integer
+    :param num_str: number string
+    """
+
+    radix = 16 if num_str.startswith('0x') else 10
+    try:
+        return int(num_str, radix)
+    except:
+        logger.error(error_message)
+        raise
+
+def find_manifest_files(start_dir):
+    """
+    Find all the manifest files in the current directory tree.
+    The current convention is to name the manifest files as 'box_*.xml'
+    with the main box file named 'box_main.xml'.
+    :param start_dir: root directory to search
+    """
+
+    manifest_files = []
+    for dirpath, dirnames, filenames in os.walk(start_dir):
+        for filename in fnmatch.filter(filenames, 'box_*.xml'):
+            manifest_files.append(os.path.join(dirpath, filename))
+    return manifest_files
+
+
+def read_manifest_file(manifest_file):
+    """
+    Load partition manifest file and construct a dictionary from it while
+    validating the file contents
+    :param manifest_file: manifest file name with a path
+    """
+
+    # Load partition manifest file.
+    manifest = etree.parse(manifest_file, etree.XMLParser(dtd_validation=True)).getroot()
+
+    # Define partition dictionary.
+    stack_size_str = manifest.find('stack').get('size')
+    heap_size_str = manifest.find('heap').get('size')
+    partition = {
+        'file': manifest_file,
+
+        'partition_name': manifest.get('name'),
+        'priority': manifest.get('priority'),
+        'entry_point': manifest.find('code').get('entry_point'),
+        'stack_size': to_number(stack_size_str,
+            'Stack size in "%s" must be a number, "%s" given.' % (manifest_file, stack_size_str)),
+        'heap_size': to_number(heap_size_str,
+            'Heap size in "%s" must be a number, "%s" given.' % (manifest_file, heap_size_str)),
+
+        # The next field is only relevant for the current uVisor implementation, should be
+        # removed in the future.
+        'context_structure_name': manifest.find('context_structure_name').text,
+    }
+
+    # Parse MMIO sections if present.
+    mmio = manifest.find('mmio')
+    mmio_region_list = []
+
+    # Named MMIO regions.
+    mmio_regions_named = mmio.findall('mmioregion_named') if mmio is not None else []
+    for mmio_region in mmio_regions_named:
+        region_description = {
+            'base': mmio_region.get('base'),
+            'permissions': mmio_region.get('permissions')
+        }
+        mmio_region_list.append(region_description)
+
+    # Numeric MMIO regions.
+    mmio_regions = mmio.findall('mmioregion') if mmio is not None else []
+    for mmio_region in mmio_regions:
+        base_str = mmio_region.get('base')
+        size_str = mmio_region.get('size')
+        region_description = {
+            'base': to_number(base_str,
+                'MMIO region base in "%s" must be a number, "%s" given.' % (manifest_file, base_str)),
+            'size': to_number(size_str,
+                'MMIO region size in "%s" must be a number, "%s" given.' % (manifest_file, size_str)),
+            'permissions': mmio_region.get('permissions')
+        }
+        mmio_region_list.append(region_description)
+
+    if mmio_region_list:
+        partition['mmio_regions'] = mmio_region_list
+
+    # Parse the SFIDs.
+    sfids = manifest.findall('sfid')
+    sfid_list = [sfid.text for sfid in sfids]
+    if sfid_list:
+        partition['sfids'] = sfid_list
+
+    # Parse the source file list and check the files for existence.
+    src_files  = manifest.find('src').findall('filename')
+    src_file_list = [src_file.text for src_file in src_files]
+
+    manifest_file_dir = os.path.dirname(manifest_file)
+    for src_file in src_file_list:
+        src_file_path = os.path.join(manifest_file_dir, src_file)
+        if not os.path.isfile(src_file_path):
+            raise ValueError('The source file "%s" mentioned in "%s" doesn\'t exist.' % (src_file, manifest_file))
+
+    partition['src_files'] = src_file_list
+
+    # Parse the IRQs.
+    irqs = manifest.findall('irq_num')
+    irq_list = []
+    for irq in irqs:
+        irq_num = to_number(irq.text, 'IRQ in "%s" must be a number, "%s" given.' % (manifest_file, irq.text))
+        irq_list.append(irq_num)
+    if irq_list:
+        partition['irqs'] = irq_list
+
+    # Parse SFID dependencies.
+    extern_sfids = manifest.findall('extern_sfid')
+    extern_sfid_list = [sfid.text for sfid in extern_sfids]
+    if extern_sfid_list:
+        partition['extern_sfids'] = extern_sfid_list
+
+    # The following fields are only relevant for the current uVisor implementation, should be
+    # removed in the future.
+    spm_status = manifest.find('spm_status')
+    if spm_status is not None:
+        partition['spm_status'] = spm_status.text
+
+    global_heap = manifest.find('global_heap')
+    if global_heap is not None:
+        page_size = global_heap.get('page_size')
+        partition['global_heap_page_size'] = to_number(page_size,
+            'Global heap page size in "%s" must be a number, "%s" given.' % (manifest_file, page_size))
+        minimal_page_number = global_heap.get('minimal_page_number')
+        partition['global_heap_minimal_page_number'] = to_number(minimal_page_number,
+            'Global heap minimal page number in "%s" must be a number, "%s" given.' %
+            (manifest_file, minimal_page_number))
+
+    return partition
+
+def validate_partition_manifests(manifests):
+    """
+    Checks the correctness of the manifest file list (no conflicts, no missing elements, etc.)
+    :param manifests: a list of the partition manifests
+    """
+
+    # Make sure the partition names are unique.
+    start = 1
+    for manifest1 in manifests[:-1]:
+        for manifest2 in manifests[start:]:
+            if manifest1['partition_name'] == manifest2['partition_name']:
+                raise ValueError('Partition name "%s" is not unique, found in both "%s" and "%s".' %
+                                     (manifest1['partition_name'], manifest1['file'], manifest2['file']))
+        start += 1
+
+    # Make sure all the SFIDs are unique,
+    # construct a list of all the SFIDs first (will be also used for SFID dependency checks).
+    sfids = [];
+    for manifest in manifests:
+        if 'sfids' in manifest:
+            for sfid in manifest['sfids']:
+                sfids.append({'sfid': sfid, 'file': manifest['file']})
+
+    start = 1
+    for sfid1 in sfids[:-1]:
+        for sfid2 in sfids[start:]:
+            if sfid1['sfid'] == sfid2['sfid']:
+                raise ValueError('SFID declaration "%s" is found in both "%s" and "%s".' %
+                                     (sfid1['sfid'], sfid1['file'], sfid2['file']))
+        start += 1
+
+    # Check for IRQ conflicts.
+    start = 1
+    for manifest1 in manifests[:-1]:
+        for manifest2 in manifests[start:]:
+            if 'irqs' in manifest1 and 'irqs' in manifest2:
+                irqs1 = manifest1['irqs']
+                irqs2 = manifest2['irqs']
+                for irq1 in irqs1:
+                    for irq2 in irqs2:
+                        if irq1 == irq2:
+                            raise ValueError('IRQ %d (0x%x) is required by both "%s" and "%s".' %
+                                                 (irq1, irq1, manifest1['file'], manifest2['file']))
+        start += 1
+
+    # Check that all the external SFIDs can be found.
+    declared_sfids = set([sfid['sfid'] for sfid in sfids])
+    for manifest in manifests:
+        if 'extern_sfids' in manifest:
+            missing_sfids = set(manifest['extern_sfids']) - declared_sfids
+            if missing_sfids:
+                raise ValueError('External SFID(s) "%s" required by "%s" can\'t be found in any partition manifest.' %
+                                 ('", "'.join(missing_sfids), manifest['file']))
+
+
+def generate_common_code(manifests, code_template, output_dir):
+    """
+    Geneartes C code from the manifest files using a given template
+    :param manifests: parsed manifest files that passed initial checks
+    """
+
+    # Create a list of all the defined MMIO regions.
+    region_list = []
+    for manifest in manifests:
+        if 'mmio_regions' in manifest:
+            region_list += manifest['mmio_regions']
+
+    # Create a list of all the MMIO region pairs that will be
+    # used for overlap checks.
+    region_pair_list = []
+    if len(region_list) > 1:
+        start = 1
+        for region1 in region_list[:-1]:
+            for region2 in region_list[start:]:
+                region_pair_list.append({'region1': region1, 'region2': region2})
+            start += 1
+
+    # Render the template.
+    rendered_template = code_template.render(region_pair_list=region_pair_list)
+
+    # Generate the code file for inclusion.
+    rendered_filename = os.path.join(output_dir, 'partition_common.inc')
+
+    with open(rendered_filename, 'w') as rendered_file:
+        rendered_file.write(rendered_template)
+
+def generate_partition_code(manifest, code_template, output_dir):
+    """
+    Genearte C code from the manifest file using a given template
+    :param manifest_file: manifest file name with a path
+    :param box_configuration_template: configuration template file name
+    :param output_dir: a directory for the generated C files
+    """
+
+    # Render the template.
+    rendered_template = code_template.render(manifest)
+
+    # Generate the code file for inclusion.
+    rendered_filename = os.path.join(output_dir, 'partition_description_' + manifest['partition_name'] + '.inc')
+
+    with open(rendered_filename, 'w') as rendered_file:
+        rendered_file.write(rendered_template)
+
+
+def process_manifest_files(manifest_files, output_dir):
+    """
+    Process all the given manifest files
+    :param manifest_files: a list of manifest files
+    :param output_dir: a directory for the generated C files
+    """
+
+    # Construct a list of all the manifests.
+    manifests = [read_manifest_file(manifest_file) for manifest_file in manifest_files]
+
+    # Validate the correctness of the manifest collection.
+    validate_partition_manifests(manifests)
+
+    # Load templates for the code generation.
+    env = Environment(
+        loader=FileSystemLoader(os.path.join(script_dir, 'templates')),
+        lstrip_blocks=True,
+        trim_blocks=True
+    )
+
+    # Generate common code.
+    generate_common_code(manifests, env.get_template('common_configuration.tpl'), output_dir)
+
+    # Generate per-partition code.
+    for manifest in manifests:
+        if os.path.basename(manifest['file']) == 'box_main.xml':
+            code_template = env.get_template('main_box_configuration.tpl')
+        else:
+            code_template = env.get_template('box_configuration.tpl')
+        generate_partition_code(manifest, code_template, output_dir)
+
+
+def main():
+    logging.basicConfig(
+        stream=sys.stdout,
+        level=logging.INFO,
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    )
+
+    parser = argparse.ArgumentParser(
+        description='Generate partition code from PSA manifest files',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument(
+        'workspace',
+        action=StoreInputDir,
+        help='Workspace root directory that is searched for PSA manifest files'
+    )
+
+    parser.add_argument(
+        'output_dir',
+        action=StoreOutputDir,
+        help='Output directory for the generated source files'
+    )
+
+    args = parser.parse_args()
+
+    process_manifest_files(find_manifest_files(args.workspace), args.output_dir)
+
+
+if __name__ == '__main__':
+    main()

--- a/manifests/box_led1.xml
+++ b/manifests/box_led1.xml
@@ -1,0 +1,19 @@
+<!DOCTYPE partition SYSTEM "partition_description.dtd">
+<partition name = "box_led1" priority = "osPriorityNormal">
+
+<code entry_point = "led1_main"/>
+
+<stack size = "512"/>
+
+<heap size = "2048"/>
+
+<src>
+<filename>../source/led1.cpp</filename>
+</src>
+
+<!-- uVisor extensions -->
+<context_structure_name>box_context</context_structure_name>
+
+<global_heap page_size = "0x1000" minimal_page_number = "8"/>
+
+</partition>

--- a/manifests/box_led2.xml
+++ b/manifests/box_led2.xml
@@ -1,0 +1,17 @@
+<!DOCTYPE partition SYSTEM "partition_description.dtd">
+<partition name = "box_led2" priority = "osPriorityNormal">
+
+<code entry_point = "led2_main"/>
+
+<stack size = "512"/>
+
+<heap size = "2048"/>
+
+<src>
+<filename>../source/led2.cpp</filename>
+</src>
+
+<!-- uVisor extensions -->
+<context_structure_name>box_context</context_structure_name>
+
+</partition>

--- a/manifests/box_led3.xml
+++ b/manifests/box_led3.xml
@@ -1,0 +1,17 @@
+<!DOCTYPE partition SYSTEM "partition_description.dtd">
+<partition name = "box_led3" priority = "osPriorityNormal">
+
+<code entry_point = "led3_main"/>
+
+<stack size = "512"/>
+
+<heap size = "2048"/>
+
+<src>
+<filename>../source/led3.cpp</filename>
+</src>
+
+<!-- uVisor extensions -->
+<context_structure_name>box_context</context_structure_name>
+
+</partition>

--- a/manifests/box_main.xml
+++ b/manifests/box_main.xml
@@ -1,0 +1,29 @@
+<!DOCTYPE partition SYSTEM "partition_description.dtd">
+<partition name = "box_main" priority = "osPriorityNormal">
+
+<code entry_point = "main"/>
+
+<stack size = "512"/>
+
+<heap size = "2048"/>
+
+<mmio>
+<mmioregion_named base = "CMU" permissions = "UVISOR_TACLDEF_PERIPH"/>
+<mmioregion_named base = "MSC" permissions = "UVISOR_TACLDEF_PERIPH"/>
+<mmioregion_named base = "GPIO" permissions = "UVISOR_TACLDEF_PERIPH"/>
+<mmioregion_named base = "TIMER0" permissions = "UVISOR_TACLDEF_PERIPH"/>
+<mmioregion_named base = "UART0" permissions = "UVISOR_TACLDEF_PERIPH"/>
+<mmioregion base = "0x0FE08000" size = "0x1000" permissions = "UVISOR_TACLDEF_PERIPH"/>
+<mmioregion base = "0x42000000" size = "0x2000000" permissions = "UVISOR_TACLDEF_PERIPH"/>
+</mmio>
+
+<src>
+<filename>../source/main.cpp</filename>
+</src>
+
+<!-- uVisor extensions -->
+<spm_status>UVISOR_ENABLED</spm_status>
+<context_structure_name>box_context</context_structure_name>
+<global_heap page_size = "2048" minimal_page_number = "8"/>
+
+</partition>

--- a/manifests/partition_description.dtd
+++ b/manifests/partition_description.dtd
@@ -1,0 +1,48 @@
+<!ELEMENT partition (code, stack, heap, mmio?, sfid*, src+, irq_num*, extern_sfid*,
+    spm_status?, context_structure_name, global_heap?)>
+<!ATTLIST partition name CDATA #REQUIRED>
+<!ATTLIST partition priority CDATA #REQUIRED>
+
+<!-- Code section definition -->
+<!ELEMENT code EMPTY>
+<!ATTLIST code entry_point CDATA #REQUIRED>
+
+<!-- Stack size definition -->
+<!ELEMENT stack EMPTY>
+<!ATTLIST stack size CDATA #REQUIRED>
+
+<!-- Heap size definition -->
+<!ELEMENT heap EMPTY>
+<!ATTLIST heap size CDATA #REQUIRED>
+
+<!-- MMIO regions -->
+<!ELEMENT mmio (mmioregion_named*, mmioregion*)>
+<!ELEMENT mmioregion_named EMPTY>
+<!ATTLIST mmioregion_named base CDATA #REQUIRED>
+<!ATTLIST mmioregion_named permissions CDATA #REQUIRED>
+<!ELEMENT mmioregion EMPTY>
+<!ATTLIST mmioregion base CDATA #REQUIRED>
+<!ATTLIST mmioregion size CDATA #REQUIRED>
+<!ATTLIST mmioregion permissions CDATA #REQUIRED>
+
+<!-- Declaration of SFIDs -->
+<!ELEMENT sfid (#PCDATA)>
+
+<!-- Source files -->
+<!ELEMENT src (filename+)>
+<!ELEMENT filename (#PCDATA)>
+
+<!-- Reserved IRQ numbers -->
+<!ELEMENT irq_num (#PCDATA)>
+
+<!-- SFID dependencies -->
+<!ELEMENT extern_sfid (#PCDATA)>
+
+<!--uVisor extensions -->
+<!ELEMENT spm_status (#PCDATA)>
+
+<!ELEMENT context_structure_name (#PCDATA)>
+
+<!ELEMENT global_heap EMPTY>
+<!ATTLIST global_heap page_size CDATA #REQUIRED>
+<!ATTLIST global_heap minimal_page_number CDATA #REQUIRED>

--- a/source/led1.cpp
+++ b/source/led1.cpp
@@ -9,20 +9,7 @@ struct box_context {
     uint32_t heartbeat;
 };
 
-static const UvisorBoxAclItem acl[] = {
-};
-
-static void led1_main(const void *);
-
-/* Box configuration
- * We do not need large stacks in either the main nor the interrupt thread, as
- * we do not do anything special in them. */
-UVISOR_BOX_NAMESPACE(NULL);
-UVISOR_BOX_HEAPSIZE(2 * 1024);
-UVISOR_BOX_MAIN(led1_main, osPriorityNormal, 512);
-UVISOR_BOX_CONFIG(box_led1, acl, 512, box_context);
-
-#define uvisor_ctx ((box_context *) __uvisor_ctx)
+#include "partition_description_box_led1.inc"
 
 static void led1_main(const void *)
 {

--- a/source/led2.cpp
+++ b/source/led2.cpp
@@ -9,20 +9,7 @@ struct box_context {
     uint32_t heartbeat;
 };
 
-static const UvisorBoxAclItem acl[] = {
-};
-
-static void led2_main(const void *);
-
-/* Box configuration
- * We do not need large stacks in either the main nor the interrupt thread, as
- * we do not do anything special in them. */
-UVISOR_BOX_NAMESPACE(NULL);
-UVISOR_BOX_HEAPSIZE(2 * 1024);
-UVISOR_BOX_MAIN(led2_main, osPriorityNormal, 512);
-UVISOR_BOX_CONFIG(box_led2, acl, 512, box_context);
-
-#define uvisor_ctx ((box_context *) __uvisor_ctx)
+#include "partition_description_box_led2.inc"
 
 static void led2_main(const void *)
 {

--- a/source/led3.cpp
+++ b/source/led3.cpp
@@ -9,20 +9,7 @@ struct box_context {
     int toggle;
 };
 
-static const UvisorBoxAclItem acl[] = {
-};
-
-static void led3_main(const void *);
-
-/* Box configuration
- * We need at least 1kB in the main thread as we use printf in it. The interrupt
- * stack size can be smaller as we do not do anything special in them. */
-UVISOR_BOX_NAMESPACE(NULL);
-UVISOR_BOX_HEAPSIZE(2 * 1024);
-UVISOR_BOX_MAIN(led3_main, osPriorityNormal, 1024);
-UVISOR_BOX_CONFIG(box_led3, acl, 512, box_context);
-
-#define uvisor_ctx ((box_context *) __uvisor_ctx)
+#include "partition_description_box_led3.inc"
 
 static void run_3(void)
 {

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -20,12 +20,7 @@
 #include "rtos.h"
 #include "main-hw.h"
 
-/* Create ACLs for main box. */
-MAIN_ACL(g_main_acl);
-
-/* Enable uVisor. */
-UVISOR_SET_MODE_ACL(UVISOR_ENABLED, g_main_acl);
-UVISOR_SET_PAGE_HEAP(2 * 1024, 8);
+#include "partition_description_box_main.inc"
 
 /* Targets with an ARMv7-M MPU needs this space adjustment to prevent a runtime
  * memory overflow error. The code below has been output directly by uVisor. */

--- a/templates/box_configuration.tpl
+++ b/templates/box_configuration.tpl
@@ -1,0 +1,18 @@
+static const UvisorBoxAclItem acl[] = {
+{% for mmio_region in mmio_regions %}
+{% if 'size' in mmio_region %}
+    { (void *){{mmio_region['base']}}, {{mmio_region['size']}}, {{mmio_region['permissions']}} },
+{% else %}
+    { {{mmio_region['base']}}, sizeof(*{{mmio_region['base']}}), {{mmio_region['permissions']}} },
+{% endif %}
+{% endfor %}
+};
+
+static void {{entry_point}}(const void *);
+
+UVISOR_BOX_NAMESPACE("{{partition_name}}");
+UVISOR_BOX_HEAPSIZE({{heap_size}});
+UVISOR_BOX_MAIN({{entry_point}}, {{priority}}, {{stack_size}});
+UVISOR_BOX_CONFIG({{partition_name}}, acl, {{stack_size}}, {{context_structure_name}});
+
+#define uvisor_ctx (({{context_structure_name}} *) __uvisor_ctx)

--- a/templates/common_configuration.tpl
+++ b/templates/common_configuration.tpl
@@ -1,0 +1,32 @@
+#ifndef COMMON_CONFIGURATION_H
+#define COMMON_CONFIGURATION_H
+
+/* Check all the defined MMIO regions for overlapping. */
+{% for region_pair in region_pair_list %}
+{% if 'size' in region_pair['region1'] and 'size' in region_pair['region2'] %}
+static_assert(
+    ({{region_pair['region1']['base']}} + {{region_pair['region1']['size']}} - 1 < {{region_pair['region2']['base']}}) ||
+    ({{region_pair['region2']['base']}} + {{region_pair['region2']['size']}} - 1 < {{region_pair['region1']['base']}}),
+    "The region with base {{region_pair['region1']['base']}} and size {{region_pair['region1']['size']}} overlaps with the region with base {{region_pair['region2']['base']}} and size {{region_pair['region2']['size']}}!");
+{% endif %}
+{% if 'size' in region_pair['region1'] and not 'size' in region_pair['region2'] %}
+static_assert(
+    ({{region_pair['region1']['base']}} + {{region_pair['region1']['size']}} - 1 < (uint32_t){{region_pair['region2']['base']}}) ||
+    ((uint32_t){{region_pair['region2']['base']}} + sizeof(*{{region_pair['region2']['base']}}) - 1 < {{region_pair['region1']['base']}}),
+    "The region with base {{region_pair['region1']['base']}} and size {{region_pair['region1']['size']}} overlaps with the region {{region_pair['region2']['base']}}!");
+{% endif %}
+{% if not 'size' in region_pair['region1'] and 'size' in region_pair['region2'] %}
+static_assert(
+    ((uint32_t){{region_pair['region1']['base']}} + sizeof(*{{region_pair['region1']['base']}}) - 1 < {{region_pair['region2']['base']}}) ||
+    ({{region_pair['region2']['base']}} + {{region_pair['region2']['size']}} - 1 < (uint32_t){{region_pair['region1']['base']}}),
+    "The region {{region_pair['region1']['base']}} overlaps with the region with base {{region_pair['region2']['base']}} and size {{region_pair['region2']['size']}}!");
+{% endif %}
+{% if not 'size' in region_pair['region1'] and not 'size' in region_pair['region2'] %}
+static_assert(
+    ((uint32_t){{region_pair['region1']['base']}} + sizeof(*{{region_pair['region1']['base']}}) - 1 < (uint32_t){{region_pair['region2']['base']}}) ||
+    ((uint32_t){{region_pair['region2']['base']}} + sizeof(*{{region_pair['region2']['base']}}) - 1 < (uint32_t){{region_pair['region1']['base']}}),
+    "The region {{region_pair['region1']['base']}} overlaps with the region {{region_pair['region2']['base']}}!");
+{% endif %}
+
+{% endfor %}
+#endif

--- a/templates/main_box_configuration.tpl
+++ b/templates/main_box_configuration.tpl
@@ -1,0 +1,12 @@
+static const UvisorBoxAclItem g_main_acl[] = {
+{% for mmio_region in mmio_regions %}
+{% if 'size' in mmio_region %}
+    { (void *){{mmio_region['base']}}, {{mmio_region['size']}}, {{mmio_region['permissions']}} },
+{% else %}
+    { {{mmio_region['base']}}, sizeof(*{{mmio_region['base']}}), {{mmio_region['permissions']}} },
+{% endif %}
+{% endfor %}
+};
+
+UVISOR_SET_MODE_ACL({{spm_status}}, g_main_acl);
+UVISOR_SET_PAGE_HEAP({{global_heap_page_size}}, {{global_heap_minimal_page_number}});


### PR DESCRIPTION
This is a prototyping of PSA partition description in XML files
in the current uVisor version.
The current implementation recurcsively searches a given folder for
XML files starting with "box_" prefix which are treated as the manifest
files.
The corresponding code templates are expected to be located in "templates"
folder.
The script that does the job is generate_partition_code.py.